### PR TITLE
Change stats modal to custom user stats instead of API data

### DIFF
--- a/spellingBee/src/Games.jsx
+++ b/spellingBee/src/Games.jsx
@@ -44,7 +44,7 @@ export default function Games({logOut, profile, userData, setUserData}) {
                 </div>
             </header>
             {returnApp(currentApp)}
-            <StatsModal />
+            <StatsModal userData={userData}/>
             <UserModal logOut={logOut} profile={profile} userData={userData}/>
             <InfoModal />
             <footer>

--- a/spellingBee/src/components/StatsModal.jsx
+++ b/spellingBee/src/components/StatsModal.jsx
@@ -1,51 +1,111 @@
-import axios from 'axios';
-import { useState, useEffect } from "react";
-import WordPieChart from "./WordPieChart";
-import './Modals.css'
+import PropTypes from 'prop-types';
+import "./Modals.css";
+import { useEffect, useState } from 'react';
+import BarGraph from "./charts/BarGraph";
 
-export default function StatsModal() {
-
-    const [apiData, setApiData] = useState({})
-
-    useEffect(()=>{
-        axios.get('https://beeyondwords.vercel.app/api/stats').then(res => {
-            setApiData(res.data)
-        })
-    }, [])
-
-    function mapData() {
-        const response = [];
-        for (const category in apiData) {
-            if (category === "words") {
-                response.push(
-                    <>
-                        <h4 className='modalSectionHead'>Total Words</h4>
-                        <h5 className='statNumber'>{apiData[category]}</h5>
-                    </>
-                )
-            } else {
-                response.push(
-                        <>
-                        <h4 className='modalSectionHead'>{category}</h4>
-                        <div className="statChart">
-                            <WordPieChart dataset={apiData[category]}/>
-                        </div>
-                        </>
-                )
-            }
-        }
-        return response;
+export default function StatsModal({userData}) {
+  const [stats, setStats] = useState(null)
+  
+  function getStats() {
+    const userStats = {
+        part: {},
+        etym: {},
+        words: 0
     }
 
-    return (
-        <dialog id="statsModal">
-            <button 
-                className='modalClose'
-                onClick={()=>{
-                    document.getElementById('statsModal').close();
-                }}><i className="bi bi-x-circle-fill"></i></button>
-            <h2 className='modalTitle'>Beeyond Words API Stats</h2>
-            {apiData && mapData().map((div, idx) => <div key={idx}>{div}</div>)}
-        </dialog>
-    )
+    for (const game in userData) {
+        for (const w of userData[game].correctWords) {
+            userStats.words++
+            if (!userStats.part[w.part_of_speech]) {
+                userStats.part[w.part_of_speech] = {
+                    correct: 1,
+                    wrong: 0
+                }   
+            } else {
+                userStats.part[w.part_of_speech].correct += 1;
+            }
+            if (!userStats.etym[w.etymology]) {
+                userStats.etym[w.etymology] = {
+                    correct: 1,
+                    wrong: 0
+                }   
+            } else {
+                userStats.etym[w.etymology].correct += 1;
+            }
+        }
+        for (const w of userData[game].wrongWords) {
+            userStats.words++
+            if (!userStats.part[w.part_of_speech]) {
+                userStats.part[w.part_of_speech] = {
+                    correct: 0,
+                    wrong: 1
+                }   
+            } else {
+                userStats.part[w.part_of_speech].wrong += 1;
+            }
+            if (!userStats.etym[w.etymology]) {
+                userStats.etym[w.etymology] = {
+                    correct: 0,
+                    wrong: 1
+                }   
+            } else {
+                userStats.etym[w.etymology].wrong += 1;
+            }
+        }
+    }
+
+    const partsData = {}
+    for (const part in userStats.part) {
+        partsData[part] = (userStats.part[part].correct / (userStats.part[part].correct + userStats.part[part].wrong)).toFixed(2) * 100
+    }
+    const etymologyData = {};
+    for (const lang in userStats.etym) {
+        etymologyData[lang] = (userStats.etym[lang].correct / (userStats.etym[lang].correct + userStats.etym[lang].wrong)).toFixed(2) * 100
+    }
+    return {totalWords: userStats.words, parts_of_speech: partsData, etymologies: etymologyData}
+
+  }
+
+  useEffect(()=>{
+    setStats(getStats())
+  }, [userData])
+
+
+  return (
+    <dialog id="statsModal">
+      <button
+        className="modalClose"
+        onClick={() => {
+          document.getElementById("statsModal").close();
+        }}
+      >
+        <i className="bi bi-x-circle-fill"></i>
+      </button>
+      <h2 className="modalTitle">Beeyond Stats</h2>
+      <p>
+        Below you will find statistics for the words you have attempted in
+        Beeyond Words.
+      </p>
+      <p>
+        These statistics represent the percentage of answers that were correct
+        in each category.
+      </p>
+      <p>
+        The statistics are compiled from both games and presented together as
+        one result.
+      </p>
+      {stats
+        ?   <>
+                <h2 className="modalSectionHead">Total Words:</h2>
+                <h3>{stats.totalWords}</h3>
+                <BarGraph data={stats.parts_of_speech} title='Parts of Speech' />
+                <BarGraph data={stats.etymologies} title='Etymologies' />
+            </>
+        :   <p>No Stats to Display</p>}
+    </dialog>
+  );
+}
+
+StatsModal.propTypes = {
+    userData: PropTypes.object
 }

--- a/spellingBee/src/components/api - StatsModal.jsx
+++ b/spellingBee/src/components/api - StatsModal.jsx
@@ -1,0 +1,75 @@
+import axios from "axios";
+import { useState, useEffect } from "react";
+import WordPieChart from "./WordPieChart";
+import "./Modals.css";
+import BarGraph from "./charts/BarGraph";
+
+export default function StatsModal() {
+  const [apiData, setApiData] = useState({});
+
+  const sample = {
+    nouns: 95,
+    verbs: 92,
+    adjectives: 68,
+    adverbs: 12,
+    interjections: 100,
+  };
+
+  useEffect(() => {
+    axios.get("https://beeyondwords.vercel.app/api/stats").then((res) => {
+      setApiData(res.data);
+    });
+  }, []);
+
+  function mapData() {
+    const response = [];
+    for (const category in apiData) {
+      if (category === "words") {
+        response.push(
+          <>
+            <h4 className="modalSectionHead">Total Words</h4>
+            <h5 className="statNumber">{apiData[category]}</h5>
+          </>
+        );
+      } else {
+        response.push(
+          <>
+            <h4 className="modalSectionHead">{category}</h4>
+            <div className="statChart">
+              <WordPieChart dataset={apiData[category]} />
+            </div>
+          </>
+        );
+      }
+    }
+    return response;
+  }
+
+  return (
+    <dialog id="statsModal">
+      <button
+        className="modalClose"
+        onClick={() => {
+          document.getElementById("statsModal").close();
+        }}
+      >
+        <i className="bi bi-x-circle-fill"></i>
+      </button>
+      <h2 className="modalTitle">Beeyond Stats</h2>
+      <p>
+        Below you will find statistics for the words you have attempted in
+        Beeyond Words.
+      </p>
+      <p>
+        These statistics represent the percentage of answers that were correct
+        in each category.
+      </p>
+      <p>
+        The statistics are compiled from both games and presented together as
+        one result.
+      </p>
+      <BarGraph data={sample} title="Parts of Speech" />
+      {apiData && mapData().map((div, idx) => <div key={idx}>{div}</div>)}
+    </dialog>
+  );
+}

--- a/spellingBee/src/components/charts/BarGraph.css
+++ b/spellingBee/src/components/charts/BarGraph.css
@@ -1,0 +1,46 @@
+.graphFrame {
+    width: 100%;
+    max-width: 500px;
+    padding: 1rem 0;
+    margin: 2rem 0;
+    border: 1px solid #ffffff88;
+    border-radius: 0.5rem;
+}
+.graphTitle {
+    font-size: x-large;
+    text-align: center;
+    width: 100%;
+    margin: 0.5rem 0 1rem;
+    color: #ffffffaa;
+}
+.graphContainer {
+    display: grid;
+    grid-template-columns: 40% 60%;
+    margin: 0.5rem;
+    color: #ffffffdd;
+}
+.dataLabelContainer,
+.dataBarContainer {
+    width: 100%;
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.25rem;
+}
+.dataLabel {
+    border-right: 1px solid #fff;
+    margin: 0;
+    padding: 0.5rem 0.25rem;
+}
+.dataBar {
+    padding: 0.5rem 0.25rem;
+    min-height: 2.5rem;
+    position: relative;
+}
+.dataBar span {
+    display: inline-block;
+    position: absolute;
+    top: 50%;
+    right: 0;
+}

--- a/spellingBee/src/components/charts/BarGraph.jsx
+++ b/spellingBee/src/components/charts/BarGraph.jsx
@@ -1,0 +1,53 @@
+import PropTypes from "prop-types";
+import "./BarGraph.css";
+
+export default function BarGraph({ data, title }) {
+  const colors = [
+    "#4fc2dc88",
+    "#9a4fdc88",
+    "#dc984f88",
+    "#7edc4f88",
+    "#dc4fad88",
+    "#dcd74f88",
+  ];
+  let colorIdx = -1;
+
+  return (
+    <div className="graphFrame">
+      <h3 className="graphTitle">{title}</h3>
+      <div className="graphContainer">
+        <div className="dataLabelContainer">
+          {Object.keys(data).map((label, idx) => (
+            <p className="dataLabel" key={idx + label}>
+              {label.length < 14 ? label : label.substring(0,10)+"..."}
+            </p>
+          ))}
+        </div>
+        <div className="dataBarContainer">
+          {Object.values(data).map((bar, idx) => {
+            colorIdx = colorIdx < colors.length - 1 ? colorIdx + 1 : 0;
+            return (
+              <div
+                className="dataBar"
+                key={idx + String(bar)}
+                style={{ width: `${bar}%`, backgroundColor: colors[colorIdx] }}
+              >
+                <span
+                  style={{ translate: bar > 30 ? "-20% -50%" : "120% -50%" }}
+                  className="barLabel"
+                >
+                  {bar}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+BarGraph.propTypes = {
+  data: PropTypes.object.isRequired,
+  title: PropTypes.string,
+};


### PR DESCRIPTION
Custom bar graph created (re-useable)
User stats update immediately with use.
Total words, plus etymology and part of speech percentages displayed.